### PR TITLE
Updated Linter Output File

### DIFF
--- a/androidllinttoglqc/androidllinttoglqc.py
+++ b/androidllinttoglqc/androidllinttoglqc.py
@@ -41,24 +41,24 @@ def parse_xml(xml_gradle_file, prefix):
     xml_to_dict = xmltodict.parse(to_string)
 
     for i in guaranteed_list(xml_to_dict['issues']['issue']):
-
-        path = guaranteed_first(i['location'])['@file']
-        cleared_path = clear_file_path(path=path, prefix=prefix)
-
-        issue = {
-            "description": i['@summary'],
-            "severity": severity_from_priority(int(i['@priority'])),
-            "fingerprint": hashlib.md5((i['@summary'] + cleared_path).encode('utf-8')).hexdigest(),
-            "location": {
-                "path": cleared_path,
-            }
-        }
-
         if '@line' in i['location']:
-            issue["location"]["lines"] = {
-                "begin": i['location']['@line']
+            path = guaranteed_first(i['location'])['@file']
+            cleared_path = clear_file_path(path=path, prefix=prefix)
+
+            issue = {
+                "description": i['@summary'],
+                "check_name": i['@category'],
+                "severity": severity_from_priority(int(i['@priority'])),
+                "fingerprint": hashlib.md5((i['@summary'] + cleared_path + i['location'].get("@line", "0") + i['@priority']).encode('utf-8')).hexdigest(),
+                "location": {
+                    "path": cleared_path,
+                }
             }
-        data.append(issue)
+
+            issue["location"]["lines"] = {
+                "begin": int(i['location']['@line'])
+            }
+            data.append(issue)
 
     return json.dumps(data)
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
             "android-lint-to-glcq = androidllinttoglqc.androidllinttoglqc:main"
         ]
     },
-    install_requires=[],
+    install_requires=["xmltodict~=0.12.0"],
     license="MIT",
     zip_safe=False,
     keywords=["android", "lint", "gitlab", "report", "gradle"],


### PR DESCRIPTION
Hi,

I updated the Linter Output to conform to the GitLab [code quality output format](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format). Also the package does not install `xmltodict` directly (had to install it manually) so I added it to the install_requires so that pip will hopefully install it automatically.

Also the hashes where not unique enough if the same error is happening on the same file on different lines, so I added the lines and priority to the hash generation.

And `location.lines.begin` is also not optional, so now it will filter for it.